### PR TITLE
fix: declare @astrojs/markdown-remark as explicit dependency

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/check": "^0.9.9",
+        "@astrojs/markdown-remark": "7.2.1",
         "@astrojs/starlight": "^0.41.4",
         "astro": "^7.0.9",
         "sharp": "^0.35.3",

--- a/website/package.json
+++ b/website/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.9.9",
+    "@astrojs/markdown-remark": "7.2.1",
     "@astrojs/starlight": "^0.41.4",
     "astro": "^7.0.9",
     "sharp": "^0.35.3",


### PR DESCRIPTION
## Summary

Dependabot PRs #159 and #160 fail their `Build site` check because newer `@astrojs/starlight` and `astro` releases no longer install `@astrojs/markdown-remark` transitively, yet `website/astro.config.mjs` uses `markdown.remarkPlugins` (for the GitHub-admonitions plugin), which requires the `unified` processor from that package. This declares it explicitly so any astro/starlight bump can pass `astro check`.

## Type of change

<!-- Check all that apply. -->

- [ ] Workshop content (lesson Markdown, images)
- [x] Site shell (`website/` Astro + Starlight wrapper)
- [ ] Copilot configuration (`.github/copilot-instructions.md`, instructions, agents, skills)
- [x] Repo housekeeping (CI, dependabot, README, license)
- [ ] Other:

## Verification

- [x] `cd website && rm -rf dist && npm run build` succeeds (218 HTML files built)
- [ ] Lychee link check passes (not run; no content or link changes)
- [ ] External GitHub URLs that I changed have been clicked manually (no URL changes)

`npm run check:all` (the step that was failing in CI, `astro check`) also passes locally.

## Screenshots

N/A

## Notes for reviewers

Astro pins `@astrojs/markdown-remark` to an exact version per release, so a caret range cannot be used. This fix pins `7.2.1` to match the current base `astro@7.0.9`, which is a no-op for the resolved tree today (it was already present transitively) but keeps it installed once starlight/astro drop the transitive dependency.

Coupling to be aware of when rebasing the Dependabot PRs:

- PR #159 (starlight bump, astro stays 7.0.9) requires `markdown-remark@7.2.1` and will pass once rebased onto this fix.
- PR #160 (astro to 7.1.6) requires `markdown-remark@7.2.2`, so that PR will additionally need `markdown-remark` bumped to `7.2.2` to resolve. Now that it is a direct dependency, Dependabot should carry it along in future updates.